### PR TITLE
fix: [P2] SessionManager.start is not idempotent and leaks duplicate health-check intervals

### DIFF
--- a/src/SessionManager.ts
+++ b/src/SessionManager.ts
@@ -618,6 +618,9 @@ export class SessionManager extends EventEmitter {
   // ===========================================================================
 
   private startHealthChecks(): void {
+    // Clear any existing intervals to ensure idempotency
+    this.stopHealthChecks()
+
     // Check tmux session health every 10 seconds
     this.healthCheckInterval = setInterval(() => {
       this.checkTmuxHealth().catch((err) => {


### PR DESCRIPTION
Fixes #19

Reviewed and approved by Wiz Reviewer.