### PR TITLE
Add UI agent handoff docs and README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,36 @@ const MyAdapter: AgentAdapter = {
 }
 ```
 
+## UI Agent Handoff Pattern
+
+The bridge enables a powerful delegation pattern: a supervising agent (e.g., OpenAI Codex) can spawn and monitor Claude Code sessions for UI work, while it focuses on backend or orchestration tasks.
+
+```
+Supervisor agent (Codex, Claude, etc.)
+  └─→ coding-agent-bridge (REST API + tmux session manager)
+        └─→ Claude Code (UI worker, in tmux with --chrome)
+              └─→ implements frontend features
+```
+
+### How it works
+
+1. **Start the bridge** — `coding-agent-bridge server`
+2. **Spawn a Claude session in tmux** — directly or via the REST API
+3. **Send scoped UI prompts** — one feature per prompt, with a structured "definition of done"
+4. **Monitor for completion** — via hook events, WebSocket, or tmux polling
+5. **Validate and iterate** — capture output, run tests, send the next prompt
+
+The `--chrome` flag gives Claude Code browser control for visual verification. The `--dangerously-skip-permissions` flag allows autonomous operation without approval prompts.
+
+### Key principles
+
+- Backend contracts are owned by the backend agent; the UI agent adapts to them
+- UI agent outputs evidence: changed files, test results, build status, screenshots, risks
+- Small iterations: one scoped prompt, then verify, rather than long unattended runs
+- Monitor frequently using hook events or tmux polling
+
+See `docs/UI_AGENT_HANDOFF_RUNBOOK.md` for the full step-by-step runbook, `docs/UI_AGENT_PROMPTS.md` for an example prompt sequence, and `docs/AGENT_MONITOR.md` for the monitoring pattern.
+
 ## Architecture
 
 ```

--- a/docs/AGENT_MONITOR.md
+++ b/docs/AGENT_MONITOR.md
@@ -1,0 +1,48 @@
+# Agent Monitor Pattern
+
+Companion runbook: `docs/UI_AGENT_HANDOFF_RUNBOOK.md` (end-to-end UI delegation flow).
+
+This describes the monitor pattern for supervising Claude/Codex sessions in tmux. The monitor combines:
+- event-driven stop detection from `events.jsonl` (written by bridge hooks)
+- tmux pane polling for output/activity changes
+
+Implement this as a script in your project, or connect directly to the bridge WebSocket (`ws://127.0.0.1:4003/ws`) for real-time events.
+
+## Example Interface
+
+```bash
+node scripts/monitor-agent-session.mjs --tmux-session ui-agent
+```
+
+## Suggested Options
+
+| Option | Description |
+|---|---|
+| `--tmux-session` | tmux session name to poll |
+| `--session-id` | bridge session UUID to filter events |
+| `--cwd` | working directory of the agent |
+| `--poll-ms` | tmux polling interval (default: 2000) |
+| `--idle-ms` | idle timeout before warning (default: 30000) |
+| `--no-exit-on-stop` | keep running after stop is detected |
+
+## Event Sources
+
+- Event files (auto-discover):
+  - `~/.coding-agent-bridge/data/events.jsonl`
+  - `~/.cin-interface/data/events.jsonl`
+- Bridge WebSocket: `ws://127.0.0.1:4003/ws`
+
+## Events to Emit
+
+A monitor implementation should emit structured JSON logs for:
+- `monitor_start` — monitor is running
+- `tmux_output_changed` — new output detected in tmux pane
+- `agent_event` — hook event received from events.jsonl
+- `stop_detected` — agent finished (Stop/SubagentStop)
+- `idle_warning` — no activity for `--idle-ms`
+- `tmux_session_gone` — tmux session no longer exists
+
+## Exit Behavior
+
+- Exit `0` on `Stop`/`SubagentStop` by default
+- With `--no-exit-on-stop`, continue running and emit the event

--- a/docs/UI_AGENT_HANDOFF_RUNBOOK.md
+++ b/docs/UI_AGENT_HANDOFF_RUNBOOK.md
@@ -1,0 +1,196 @@
+# UI Agent Handoff Runbook (Claude Code via tmux + Bridge)
+
+This runbook describes how to delegate UI/UX work to Claude Code while a supervising agent (Codex, another Claude instance, etc.) handles backend or orchestration work.
+
+## 1) Source Repos and Capabilities
+
+- `coding-agent-bridge`
+  - Provides: tmux-backed session manager for Claude/Codex, hook/event plumbing.
+
+Primary docs:
+- `coding-agent-bridge/README.md`
+- `docs/AGENT_MONITOR.md`
+- `docs/UI_AGENT_PROMPTS.md`
+
+## 2) Prerequisites
+
+Required CLIs:
+- `tmux`
+- `claude`
+- `node` (>=18)
+- `npm`
+
+Recommended:
+- `coding-agent-bridge` CLI available globally, or run bridge from local repo.
+
+## 3) One-Time Setup
+
+From bridge repo:
+
+```bash
+cd <bridge-repo>
+npm install
+node bin/cli.js setup
+```
+
+What setup does:
+- installs hook scripts so Claude/Codex events flow into an events log
+- enables reliable stop detection and tool-level monitoring
+
+Event file paths to watch:
+- `~/.cin-interface/data/events.jsonl`
+- fallback: `~/.coding-agent-bridge/data/events.jsonl`
+
+## 4) Start Services (Backend + Bridge)
+
+Terminal A (your project's backend, if applicable):
+
+```bash
+cd <your-project>
+npm run start:api    # or whatever starts your backend
+```
+
+Terminal B (bridge server):
+
+```bash
+cd <bridge-repo>
+node bin/cli.js server --debug
+```
+
+Health check:
+
+```bash
+curl http://127.0.0.1:4003/health
+```
+
+## 5) Launch Claude UI Session in tmux
+
+### Direct tmux launch (fastest)
+
+```bash
+cd <your-project>
+tmux new-session -d -s ui-agent
+
+# Start Claude with browser control + relaxed permissions for implementation speed
+tmux send-keys -t ui-agent 'cd <your-project> && claude --dangerously-skip-permissions --chrome' Enter
+```
+
+Then send your UI prompt into the same pane.
+
+### Prompt source files
+- `docs/UI_AGENT_PROMPTS.md` (example prompt sequence)
+- Adapt the prompt sequence to your project's UI needs
+
+## 6) Monitoring Loop (Stop Signal + Polling)
+
+The bridge emits events via WebSocket (`ws://127.0.0.1:4003/ws`) and writes to `events.jsonl`. You can build a monitor script in your project that combines event-driven stop detection with tmux output polling. See `docs/AGENT_MONITOR.md` for the expected interface.
+
+Example monitor usage (you supply this script in your project):
+
+```bash
+node scripts/monitor-agent-session.mjs --tmux-session ui-agent
+```
+
+Useful options:
+
+```bash
+node scripts/monitor-agent-session.mjs \
+  --tmux-session ui-agent \
+  --cwd <your-project> \
+  --poll-ms 2000 \
+  --idle-ms 30000
+```
+
+Behavior to implement:
+- exit `0` on `Stop`/`SubagentStop` events
+- emit JSON logs for: tmux output changes, hook events, idle warnings
+- give reliable completion detection without manual tab watching
+
+Alternatively, connect directly to the bridge WebSocket for real-time events.
+
+## 7) Handoff Prompt Template
+
+Adapt this template to your project:
+
+```text
+You are implementing UI in <your-project>/ui.
+
+Backend is live at <backend-url>.
+Do not change backend contracts.
+
+Goals:
+1) Implement requested UI feature end-to-end.
+2) Keep desktop + mobile usable.
+3) Add/adjust component tests.
+4) Run tests/build.
+
+Definition of done (must report all):
+1. Changed files
+2. Test results
+3. Build result
+4. Screenshot paths
+5. Unresolved risks
+```
+
+## 8) Review-and-Apply Workflow
+
+After Claude finishes a batch:
+
+1. Capture output:
+
+```bash
+tmux capture-pane -pt ui-agent | tail -n 120
+```
+
+2. Validate locally:
+
+```bash
+cd <your-project>
+npm test
+cd ui && npm test -- --run && npm run build
+```
+
+3. Restart backend if it was touched:
+
+```bash
+tmux new-session -d -s backend 'cd <your-project> && npm run start:api'
+```
+
+4. Verify in browser at your dev server URL (e.g. `http://127.0.0.1:5173`).
+
+## 9) Troubleshooting
+
+If Claude appears stuck:
+- Check tmux pane:
+  - `tmux capture-pane -pt ui-agent | tail -n 120`
+- Check events:
+  - `tail -f ~/.cin-interface/data/events.jsonl`
+- Verify bridge up:
+  - `curl http://127.0.0.1:4003/health`
+
+If no Chrome control behavior is visible:
+- relaunch session with `--chrome`
+- if policy permits, include `--dangerously-skip-permissions`
+
+If session exists but is stale:
+
+```bash
+tmux kill-session -t ui-agent
+```
+
+Then relaunch clean.
+
+## 10) Operating Rules for Delegated UI Work
+
+- Backend contracts are owned by the backend agent; UI agent must adapt to the contract.
+- UI agent should output evidence, not just code:
+  - files changed
+  - test/build output
+  - screenshots
+  - risk list
+- Keep iterations small: one scoped prompt, then verify.
+- Prefer frequent monitor checks over long unattended runs.
+
+## 11) Suggested Improvements
+
+The monitor pattern here should be moved into `coding-agent-bridge` as first-class completion callbacks (event + timeout + idle strategy) so supervising agents do not need custom polling scripts.

--- a/docs/UI_AGENT_PROMPTS.md
+++ b/docs/UI_AGENT_PROMPTS.md
@@ -1,0 +1,63 @@
+# UI Agent Prompt Pack (Claude Code via tmux)
+
+Runbook: see `docs/UI_AGENT_HANDOFF_RUNBOOK.md` for bridge startup, tmux launch flags (`--chrome`, `--dangerously-skip-permissions`), monitoring loop, and troubleshooting.
+
+Use these prompts as a template. Adapt endpoints, field names, and features to your project.
+If your project has a backend API, start it before running these prompts.
+
+## Prompt 1 - Static Shell
+Build the initial UI shell with:
+- stats/summary bar
+- main list view
+- detail panel
+
+Use your project's API contracts and real field names from backend responses.
+Include relevant status badges and indicators.
+
+Output required:
+1. Changed files
+2. Test results
+3. Screenshot paths (desktop + mobile)
+
+## Prompt 2 - Live API Wiring
+Wire live endpoints from your backend API.
+Add loading, retry, empty state, and error state for every view.
+Do not change backend contracts.
+
+Output required:
+1. Changed files
+2. Test results
+3. Screenshot paths
+
+## Prompt 3 - Filters and Navigation
+Implement filter/query controls relevant to your data model (e.g. type, status, search, pagination).
+Persist filters in URL. Add keyboard navigation for high-volume workflows.
+
+Output required:
+1. Changed files
+2. Test results
+3. Screenshot paths
+
+## Prompt 4 - Feature-Specific Views
+Add any domain-specific views your project needs (e.g. comparison tables, detail modals, analytics dashboards).
+Keep dependencies minimal.
+
+Output required:
+1. Changed files
+2. Test results
+3. Screenshot paths
+
+## Prompt 5 - Hardening
+Perform UX hardening for large data sets:
+- virtualization/pagination tuning
+- sticky filters
+- row-level quick actions
+- mobile layout correctness
+
+Also add/expand component tests for edge states.
+
+Output required:
+1. Changed files
+2. Test results
+3. Screenshot paths
+4. Unresolved risks list


### PR DESCRIPTION
## Summary
- Add generic docs for the UI agent handoff pattern (delegating UI work to Claude Code from a supervising agent like Codex)
- `docs/UI_AGENT_HANDOFF_RUNBOOK.md` — full step-by-step runbook for launching, monitoring, and reviewing delegated UI sessions
- `docs/UI_AGENT_PROMPTS.md` — example 5-prompt sequence template (static shell → API wiring → filters → feature views → hardening)
- `docs/AGENT_MONITOR.md` — monitor pattern spec for supervising tmux-based agent sessions
- Add "UI Agent Handoff Pattern" section to README explaining the supervisor-to-Claude-Code delegation flow

## Test plan
- [ ] Verify docs render correctly on GitHub
- [ ] Confirm no personal paths or project-specific references leaked
- [ ] Review runbook flow for completeness from a new user's perspective

🤖 Generated with [Claude Code](https://claude.com/claude-code)